### PR TITLE
Support wasm32v1-none

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -15,6 +15,12 @@ jobs:
       - name: Install Rust toolchain
         run: rustup default nightly
 
+      - name: Install wasm32v1-none
+        run: rustup target add wasm32v1-none
+
+      - name: Embedded
+        run: cargo check --target wasm32v1-none -Zavoid-dev-deps
+
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,19 +14,26 @@ exclude = ["asset"]
 [dependencies.emit]
 version = "1"
 default-features = false
-features = ["std", "serde"]
+features = ["serde"]
 
 [dependencies.serde]
 version = "1"
+default-features = false
 
 [dependencies.wasm-bindgen]
 version = "0.2"
-
-[dependencies.serde-wasm-bindgen]
-version = "0.6"
+default-features = false
 
 [dependencies.js-sys]
 version = "0.3"
+default-features = false
+
+[dev-dependencies.wasm-bindgen]
+version = "0.2"
+
+[dev-dependencies.emit]
+version = "1"
+features = ["serde"]
 
 [dev-dependencies.wasm-bindgen-test]
 version = "0.3"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Use [`emit`](https://docs.rs/emit) in WebAssembly applications targeting NodeJS and the browser.
 
+`emit` itself and some emitters, like [`emit_otlp`](https://docs.rs/emit_otlp) support WebAssembly directly. This library includes support for emitting events to the [Console API](https://developer.mozilla.org/en-US/docs/Web/API/console). It also has alternative clocks and randomness using different web features. These aren't required for configuration, but can be used to more directly control the JavaScript APIs `emit` makes use of.
+
 # Getting started
 
 First, add `emit` and `emit_web` to your `Cargo.toml`:
@@ -13,15 +15,11 @@ First, add `emit` and `emit_web` to your `Cargo.toml`:
 ```toml
 [dependencies.emit]
 version = "1"
-# Important: Make sure you set `default-features = false`
-default-features = false
 features = ["std", "implicit_rt"]
 
 [dependencies.emit_web]
 version = "0.2.0"
 ```
-
-Ensure you set `default-features = false` on `emit`, so it won't try compile dependencies that aren't compatible with WebAssembly.
 
 Next, configure `emit` to use web APIs in its runtime:
 
@@ -32,14 +30,11 @@ use wasm_bindgen::prelude::*;
 pub fn setup() {
     let _ = emit::setup()
         .emit_to(emit_web::console())
-        .with_clock(emit_web::date_clock())
-        .with_rng(emit_web::crypto_rng())
         .try_init();
 }
 ```
 
-The name of this function doesn't matter, you'll just need to call it somewhere early in your application.
-You'll need to at least override the default clock and source of randomness, otherwise you'll get events without timestamps, and spans without ids.
+The name of this `setup` function doesn't matter, you'll just need to call it somewhere early in your application.
 
 # Output
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Use [`emit`](https://docs.rs/emit) in WebAssembly applications targeting NodeJS 
 
 `emit` itself and some emitters, like [`emit_otlp`](https://docs.rs/emit_otlp) support WebAssembly directly. This library includes support for emitting events to the [Console API](https://developer.mozilla.org/en-US/docs/Web/API/console). It also has alternative clocks and randomness using different web features. These aren't required for configuration, but can be used to more directly control the JavaScript APIs `emit` makes use of.
 
+`emit_web` also supports the `wasm32v1-none` target.
+
 # Getting started
 
 First, add `emit` and `emit_web` to your `Cargo.toml`:

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -9,8 +9,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies.emit]
 version = "1"
-default-features = false
-features = ["std", "implicit_rt"]
 
 [dependencies.emit_web]
 path = "../"


### PR DESCRIPTION
Closes #3 

This PR makes `emit_web` support the `wasm32v1-none` target. Unlike `wasm32-unknown-unknown`, this target doesn't have access to `std`, so we need to disable those features in order to build for it.