### PR TITLE
Add a panic hook

### DIFF
--- a/.github/workflows/web.yml
+++ b/.github/workflows/web.yml
@@ -19,13 +19,19 @@ jobs:
         run: rustup target add wasm32v1-none
 
       - name: Embedded
-        run: cargo check --target wasm32v1-none -Zavoid-dev-deps
+        run: cargo check --no-default-features --target wasm32v1-none -Zavoid-dev-deps
 
       - name: Install
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Default features
         run: wasm-pack test --node
+
+      - name: All features
+        run: wasm-pack test --node --all-features
+
+      - name: No features
+        run: wasm-pack test --node --no-default-features
 
       - name: Example
         working-directory: example

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,10 @@ categories = ["development-tools::debugging"]
 edition = "2021"
 exclude = ["asset"]
 
+[features]
+default = ["std"]
+std = ["emit/std"]
+
 [dependencies.emit]
 version = "1"
 default-features = false

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ First, add `emit` and `emit_web` to your `Cargo.toml`:
 ```toml
 [dependencies.emit]
 version = "1"
-features = ["std", "implicit_rt"]
 
 [dependencies.emit_web]
 version = "0.2.2"

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -15,6 +15,3 @@ path = "../"
 
 [dependencies.wasm-bindgen]
 version = "0.2"
-
-[dependencies.console_error_panic_hook]
-version = "0.1"

--- a/example/src/lib.rs
+++ b/example/src/lib.rs
@@ -2,13 +2,11 @@ use wasm_bindgen::prelude::*;
 
 #[wasm_bindgen]
 pub fn setup() {
-    std::panic::set_hook(Box::new(console_error_panic_hook::hook));
+    // Write panics to the console
+    std::panic::set_hook(Box::new(emit_web::panic_hook(emit_web::console())));
 
-    let _ = emit::setup()
-        .emit_to(emit_web::console())
-        .with_clock(emit_web::date_clock())
-        .with_rng(emit_web::crypto_rng())
-        .try_init();
+    // Write regular events to the console
+    let _ = emit::setup().emit_to(emit_web::console()).try_init();
 }
 
 #[wasm_bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,9 +37,12 @@ The name of this `setup` function doesn't matter, you'll just need to call it so
 #![deny(missing_docs)]
 #![cfg_attr(not(test), no_std)]
 
+#[cfg(feature = "std")]
+extern crate std;
+
 extern crate alloc;
 
-use alloc::string::ToString;
+use alloc::{boxed::Box, string::ToString};
 use core::{ops::ControlFlow, time::Duration};
 
 use emit::Props as _;
@@ -88,6 +91,8 @@ impl emit::Emitter for ConsoleEmitter {
         true
     }
 }
+
+impl emit::runtime::InternalEmitter for ConsoleEmitter {}
 
 fn encode_extent(extent: Option<&emit::Extent>) -> JsValue {
     let Some(extent) = extent else {
@@ -160,6 +165,29 @@ fn to_jsvalue(v: impl serde::Serialize) -> JsValue {
         Ok(value) => value,
         Err(err) => err,
     }
+}
+
+/**
+A panic hook that emits panics as error events through the given `emitter`.
+
+The given emitter **must not panic**, since it'll be called in response to panics.
+The [`console`] function offers a suitable emitter based on the [Console API](https://developer.mozilla.org/en-US/docs/Web/API/Console_API).
+*/
+#[cfg(feature = "std")]
+pub fn panic_hook(
+    emitter: impl emit::runtime::InternalEmitter + Send + Sync + 'static,
+) -> Box<dyn Fn(&std::panic::PanicHookInfo<'_>) + Send + Sync> {
+    Box::new(move |info| {
+        let err = info.payload_as_str().unwrap_or("unknown");
+        let location = info.location();
+
+        emitter.emit(emit::error_evt!(
+            "Rust panic: {err}",
+            #[emit::optional]
+            #[emit::as_display]
+            location,
+        ));
+    })
 }
 
 // NOTE: `Temporal.Now.instant()` would be good to support when available


### PR DESCRIPTION
Closes #2 

This PR adds a panic hook that can be used to write a Rust panic as an `emit` event through an internal emitter. It also adds a `std` feature, which is enabled by default, to support setting the hook.

The `emit_web::panic_hook` function isn't actually specific to the web at all, it's just not likely to be something you'll actually want to use outside of WebAssembly, so I've added it here instead of in `emit`.

**This is a breaking change**